### PR TITLE
tests(calculation-api): fixed failing integration tests and improved visiblity

### DIFF
--- a/tests/common_parameters.py
+++ b/tests/common_parameters.py
@@ -9,6 +9,8 @@ password = os.getenv("ANALYTICS_API_PASSWORD")
 base_url = 'https://api.factset.com' if not os.getenv("ANALYTICS_API_URL") else os.getenv("ANALYTICS_API_URL")
 
 pa_default_document = "PA_DOCUMENTS:DEFAULT"
+pa_default_component_name = "Weights"
+pa_default_component_category = "Weights / Exposures"
 pa_benchmark_sp500 = "BENCH:SP50"
 pa_benchmark_r1000 = "BENCH:R.1000"
 spar_default_document = "pmw_root:/spar_documents/Factset Default Document"

--- a/tests/test_calculations_api.py
+++ b/tests/test_calculations_api.py
@@ -18,7 +18,7 @@ from fds.analyticsapi.engines.models.pa_date_parameters import PADateParameters
 from fds.analyticsapi.engines.models.spar_calculation_parameters import SPARCalculationParameters
 from fds.analyticsapi.engines.models.spar_identifier import SPARIdentifier
 from fds.analyticsapi.engines.models.spar_date_parameters import SPARDateParameters
-# from fds.analyticsapi.engines.models.vault_calculation_parameters import VaultCalculationParameters
+## from fds.analyticsapi.engines.models.vault_calculation_parameters import VaultCalculationParameters
 # from fds.analyticsapi.engines.models.vault_identifier import VaultIdentifier
 # from fds.analyticsapi.engines.models.vault_date_parameters import VaultDateParameters
 from fds.analyticsapi.engines.models.pub_calculation_parameters import PubCalculationParameters

--- a/tests/test_calculations_api.py
+++ b/tests/test_calculations_api.py
@@ -6,6 +6,7 @@ from google.protobuf import json_format
 from fds.protobuf.stach.Package_pb2 import Package
 from urllib3.response import HTTPResponse
 
+from fds.analyticsapi.engines import ComponentSummary
 from fds.analyticsapi.engines.api.components_api import ComponentsApi
 from fds.analyticsapi.engines.api.configurations_api import ConfigurationsApi
 from fds.analyticsapi.engines.api.calculations_api import CalculationsApi
@@ -41,7 +42,8 @@ class TestCalculationsApi(unittest.TestCase):
     def run_calculation(self):
         components_api = ComponentsApi(self.api_client)
         components = components_api.get_pa_components(common_parameters.pa_default_document)
-        component_id = list(components.keys())[0]
+        component_desc = ComponentSummary(name=common_parameters.pa_default_component_name, category=common_parameters.pa_default_component_category)
+        component_id = [id for id in list(components.keys()) if components[id] == component_desc][0]
 
         pa_account_identifier = PAIdentifier(common_parameters.pa_benchmark_sp500)
         pa_accounts = [pa_account_identifier]

--- a/tests/test_calculations_api.py
+++ b/tests/test_calculations_api.py
@@ -125,7 +125,7 @@ class TestCalculationsApi(unittest.TestCase):
             calculations = getattr(self.status_response[0], engine).values()
             for calc in calculations:
                 self.assertEqual(type(calc), CalculationUnitStatus, "Response should be of CalculationUnitStatus type")
-                self.assertEqual(calc.status, "Success", "Calculation should be successful")
+                self.assertEqual(calc.status, "Success", "Calculation should be successful for " + engine)
                 self.assertNotEqual(calc.result, None, "Response result should not be null")
 
                 utility_api = UtilityApi(self.api_client)


### PR DESCRIPTION
**Why is this change necessary?**

- This change fixes a broken integration test that periodically fails
- When integration tests periodically fail on github actions but succeed when run locally. Visibility is a problem on failing integration tests

https://github.com/factset/analyticsapi-engines-python-sdk/runs/1696674419?check_suite_focus=true

**How does it address this issue?**

- Replaced logic in code that hardcodes grabbing first component id that has has a chance of creating a failing calculation with one that correctly identifies the right component id
- Added in `test_calculations_api.py` to specify what engine failed in the print out for calculation that did not succeed

**Why is the change done this way?**

- Smallest change to achieve desired result

**What side effects does this change have?**

- NA

**What testing was done to confirm this works?**

Integration tests that run on this pull request succeed as expected. Visibility on failing test is now viewable on failure

**Things to consider after this change**

- We might want to separate separate calculation integration tests to improve visibility on failing tests

Hank <hank.lin@factset.com>