### PR TITLE
fix(examples/credentials): updated username and password to strings

### DIFF
--- a/examples/afi_optimizer_example.py
+++ b/examples/afi_optimizer_example.py
@@ -18,8 +18,8 @@ from fds.protobuf.stach.extensions.StachVersion import StachVersion
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/axp_optimizer_example.py
+++ b/examples/axp_optimizer_example.py
@@ -20,8 +20,8 @@ from fds.protobuf.stach.extensions.StachVersion import StachVersion
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/bpm_optimizer_example.py
+++ b/examples/bpm_optimizer_example.py
@@ -18,8 +18,8 @@ from fds.protobuf.stach.extensions.StachVersion import StachVersion
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/fi_example.py
+++ b/examples/fi_example.py
@@ -17,8 +17,8 @@ from fds.protobuf.stach.extensions.StachExtensionFactory import StachExtensionFa
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/fpo_optimizer_example.py
+++ b/examples/fpo_optimizer_example.py
@@ -21,8 +21,8 @@ from fds.protobuf.stach.extensions.StachVersion import StachVersion
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/pa_engine_multiple_unit_example.py
+++ b/examples/pa_engine_multiple_unit_example.py
@@ -19,8 +19,8 @@ from fds.protobuf.stach.extensions.StachExtensionFactory import StachExtensionFa
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/pa_engine_single_unit_example.py
+++ b/examples/pa_engine_single_unit_example.py
@@ -19,8 +19,8 @@ from fds.protobuf.stach.extensions.StachExtensionFactory import StachExtensionFa
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/pub_engine_multiple_unit_example.py
+++ b/examples/pub_engine_multiple_unit_example.py
@@ -14,8 +14,8 @@ from urllib3 import Retry
 from pathlib import Path
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/pub_engine_single_unit_example.py
+++ b/examples/pub_engine_single_unit_example.py
@@ -14,8 +14,8 @@ from fds.analyticsapi.engines.model.pub_date_parameters import PubDateParameters
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/quant_engine_single_unit_example.py
+++ b/examples/quant_engine_single_unit_example.py
@@ -20,8 +20,8 @@ from fds.protobuf.stach.extensions.StachExtensionFactory import StachExtensionFa
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/quant_engine_single_unit_feather_example.py
+++ b/examples/quant_engine_single_unit_feather_example.py
@@ -18,8 +18,8 @@ from fds.analyticsapi.engines.model.quant_fql_expression import QuantFqlExpressi
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/spar_engine_multiple_unit_example.py
+++ b/examples/spar_engine_multiple_unit_example.py
@@ -19,8 +19,8 @@ from fds.protobuf.stach.extensions.StachExtensionFactory import StachExtensionFa
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/spar_engine_single_unit_example.py
+++ b/examples/spar_engine_single_unit_example.py
@@ -19,8 +19,8 @@ from fds.protobuf.stach.extensions.StachExtensionFactory import StachExtensionFa
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/vault_engine_multiple_unit_example.py
+++ b/examples/vault_engine_multiple_unit_example.py
@@ -20,8 +20,8 @@ from fds.protobuf.stach.extensions.StachExtensionFactory import StachExtensionFa
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():

--- a/examples/vault_engine_single_unit_example.py
+++ b/examples/vault_engine_single_unit_example.py
@@ -20,8 +20,8 @@ from fds.protobuf.stach.extensions.StachExtensionFactory import StachExtensionFa
 from urllib3 import Retry
 
 host = "https://api.factset.com"
-username = os.environ["ANALYTICS_API_QAR_USERNAME_SERIAL"]
-password = os.environ["ANALYTICS_API_QAR_PASSWORD"]
+username = "<username-serial>"
+password = "<apiKey>"
 
 
 def main():


### PR DESCRIPTION
This change updates all the examples to use hardcoded strings for the username and password to make it more understandable to clients