### PR TITLE
feat(workflow) : Updated the python version.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
     
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Currently release workflow action run is failing due to python version with below error. So to fix this updated the python version from 3.6 to 3.7 with the reference of - https://github.com/factset/stach-extensions/actions/runs/7208653726/workflow#L61

![image](https://github.com/factset/analyticsapi-engines-python-sdk/assets/82034829/c84c0b82-3e0a-4398-8687-cb2723cfea54)
